### PR TITLE
Fix TensorFlow and Python3 compatibility in notebook

### DIFF
--- a/linear-regression.ipynb
+++ b/linear-regression.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "# Construct a linear model\n",
-    "activation = tf.add(tf.mul(X, W), b)"
+    "activation = tf.add(tf.multiply(X, W), b)"
    ]
   },
   {
@@ -117,7 +117,7 @@
    "outputs": [],
    "source": [
     "# Initializing the variables\n",
-    "init = tf.initialize_all_variables()"
+    "init = tf.global_variables_initializer()"
    ]
   },
   {
@@ -186,13 +186,13 @@
     "\n",
     "        #Display logs per epoch step\n",
     "        if epoch % display_step == 0:\n",
-    "            print \"Epoch:\", '%04d' % (epoch+1), \"cost=\", \\\n",
+    "            print(\"Epoch:\", '%04d' % (epoch+1), \"cost=\", \\\n",
     "                \"{:.9f}\".format(sess.run(cost, feed_dict={X: train_X, Y:train_Y})), \\\n",
-    "                \"W=\", sess.run(W), \"b=\", sess.run(b)\n",
+    "                \"W=\", sess.run(W), \"b=\", sess.run(b))\\n",
     "\n",
-    "    print \"Optimization Finished!\"\n",
-    "    print \"cost=\", sess.run(cost, feed_dict={X: train_X, Y: train_Y}), \\\n",
-    "          \"W=\", sess.run(W), \"b=\", sess.run(b)\n",
+    "    print(\"Optimization Finished!\")\\n",
+    "    print(\"cost=\", sess.run(cost, feed_dict={X: train_X, Y: train_Y}), \\\n",
+    "          \"W=\", sess.run(W), \"b=\", sess.run(b))\\n",
     "\n",
     "    #Graphic display\n",
     "    plt.plot(train_X, train_Y, 'ro', label='Original data')\n",


### PR DESCRIPTION
## Summary
- update TensorFlow API calls in `linear-regression.ipynb`
- use Python 3 print function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbd234c1c83249091d3d4049a0cc0